### PR TITLE
emit error events instead of throwing Error

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -360,11 +360,11 @@ OutgoingMessage.prototype._finish = function _finish() {
 
 OutgoingMessage.prototype.setHeader = function setHeader(name, value) {
   if (this.headersSent) {
-    throw new Error('Can\'t set headers after they are sent.');
+    return this.emit('error', new Error('Can\'t set headers after they are sent.'));
   } else {
     name = name.toLowerCase();
     if (deprecatedHeaders.indexOf(name) !== -1) {
-      throw new Error('Cannot set deprecated header: ' + name);
+      return this.emit('error', new Error('Cannot set deprecated header: ' + name));
     }
     this._headers[name] = value;
   }
@@ -372,7 +372,7 @@ OutgoingMessage.prototype.setHeader = function setHeader(name, value) {
 
 OutgoingMessage.prototype.removeHeader = function removeHeader(name) {
   if (this.headersSent) {
-    throw new Error('Can\'t remove headers after they are sent.');
+    return this.emit('error', new Error('Can\'t remove headers after they are sent.'));
   } else {
     delete this._headers[name.toLowerCase()];
   }
@@ -891,7 +891,7 @@ Agent.prototype.request = function request(options, callback) {
 
   if (!options.plain && options.protocol === 'http:') {
     this._log.error('Trying to negotiate client request with Upgrade from HTTP/1.1');
-    throw new Error('HTTP1.1 -> HTTP2 upgrade is not yet supported.');
+    this.emit('error', new Error('HTTP1.1 -> HTTP2 upgrade is not yet supported.'));
   }
 
   var request = new OutgoingRequest(this._log);

--- a/lib/protocol/stream.js
+++ b/lib/protocol/stream.js
@@ -625,7 +625,7 @@ Stream.prototype._transition = function transition(sending, frame) {
     // * When sending something invalid, throwing an exception, since it is probably a bug.
     if (sending) {
       this._log.error(info, 'Sending illegal frame.');
-      throw new Error('Sending illegal frame (' + frame.type + ') in ' + this.state + ' state.');
+      return this.emit('error', new Error('Sending illegal frame (' + frame.type + ') in ' + this.state + ' state.'));
     }
 
     // * In case of a serious problem, emitting and error and letting someone else handle it


### PR DESCRIPTION
Done for all operation that may be done asynchronously or in a nested
way, in an EventEmitter context.
The change allow to handle errors (by catching error events) while
keeping the original behavior (throwing error) if error events are not
listened
