### PR TITLE
Fix bug when calling request with agent option

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -942,7 +942,7 @@ Agent.prototype.request = function request(options, callback) {
     options.ciphers = options.ciphers || cipherSuites;
     if (createAgent) {
       options.agent = new https.Agent(options);
-    } else if (options.agent == null) {
+    } else {
       options.agent = this._httpsAgent;
     }
     var httpsRequest = https.request(options);


### PR DESCRIPTION
Fix https://github.com/molnarg/node-http2/issues/174

Before the internal https.Agent of http2.Agent were left to the agent from the request option (http2.Agent instance)
