### PR TITLE
Forward endpoint errors to httpsRequest

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -970,6 +970,7 @@ Agent.prototype.request = function request(options, callback) {
         endpoint = new Endpoint(self._log, 'CLIENT', self._settings);
         endpoint.socket = httpsRequest.socket;
         endpoint.pipe(endpoint.socket).pipe(endpoint);
+        endpoint.on('error', httpsRequest.emit.bind(httpsRequest, 'error'));
       }
       if (started) {
         // ** In the meantime, an other connection was made to the same host...


### PR DESCRIPTION
Needed to be able to handles thoose errors gracefully because endpoint is not exposed.
