### PR TITLE
Destroyed socket beeing reused

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -963,6 +963,10 @@ Agent.prototype.request = function request(options, callback) {
 
     httpsRequest.on('socket', function(socket) {
       var negotiatedProtocol = socket.alpnProtocol || socket.npnProtocol;
+      socket.on('agentRemove', function () {
+        if (this.destroyed && self.endpointes)
+          delete self.endpointes[key];
+      });
       if (negotiatedProtocol != null) { // null in >=0.11.0, undefined in <0.11.0
         negotiated();
       } else {


### PR DESCRIPTION
It looks like the 'agentRemove' event was not properly handled and the socket was not removed from 'endpoints' causing the client to reuse an inactive Stream.
